### PR TITLE
implement lazy loading for images

### DIFF
--- a/starter/lazyLoading.js
+++ b/starter/lazyLoading.js
@@ -1,0 +1,24 @@
+// Lazy loading images
+const imgTargets = document.querySelectorAll('img[data-src]');
+
+const loadImg = (entries, observer) => {
+  const [entry] = entries;
+  if (!entry.isIntersecting) return;
+
+  // Replace src attribute with data-src
+  entry.target.src = entry.target.dataset.src;
+  entry.target.addEventListener('load', function () {
+    entry.target.classList.remove('lazy-img');
+  });
+  observer.unobserve(entry.target);
+};
+
+const imgObserver = new IntersectionObserver(loadImg, {
+  root: null,
+  threshold: 0,
+  rootMargin: '200px',
+});
+
+imgTargets.forEach(img => {
+  imgObserver.observe(img);
+});

--- a/starter/script.js
+++ b/starter/script.js
@@ -3,3 +3,4 @@ import './reference.js';
 import './scroling.js';
 import './nav.js';
 import './tabbed.js';
+import './lazyLoading.js';


### PR DESCRIPTION
- Add IntersectionObserver to load images on viewport entry
- Use data-src attribute for deferred image loading
- Apply 200px rootMargin for early loading trigger
- Remove lazy-img class after image load completes
- Automatically unobserve images after loading

Improves page performance by:
- Reducing initial page load time
- Decreasing bandwidth usage
- Improving Lighthouse scores